### PR TITLE
Update build scripts and pick colorspace based on incoming frame

### DIFF
--- a/gui/src/avplacebowidget.cpp
+++ b/gui/src/avplacebowidget.cpp
@@ -105,6 +105,9 @@ bool AVPlaceboWidget::RenderFrame(AVFrame *frame) {
         CHIAKI_LOGE(session->GetChiakiLog(), "Failed to map AVFrame to Placebo frame!");
         return false;
     }
+    // set colorspace hint
+    struct pl_color_space hint = placebo_frame.color;
+    pl_swapchain_colorspace_hint(placebo_swapchain, &hint);
 
     pl_rect2df crop;
 

--- a/lib/src/thread.c
+++ b/lib/src/thread.c
@@ -263,7 +263,7 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_thread_timedjoin(ChiakiThread *thread, void
 #else
 	struct timespec timeout;
 	set_timeout(&timeout, timeout_ms);
-	int r = pthread_timedjoin_np(thread->thread, retval, &timeout);
+	int r = pthread_clockjoin_np(thread->thread, retval, CLOCK_MONOTONIC, &timeout);
 	if(r != 0)
 	{
 		if(r == ETIMEDOUT)

--- a/scripts/Dockerfile.focal
+++ b/scripts/Dockerfile.focal
@@ -1,0 +1,12 @@
+FROM ubuntu:focal
+
+RUN apt-get update
+RUN apt-get install -y software-properties-common gpg wget
+RUN add-apt-repository ppa:beineri/opt-qt-5.15.3-focal
+RUN add-apt-repository ppa:pipewire-debian/pipewire-upstream
+RUN apt-get update
+RUN apt-get -y install git g++ cmake ninja-build curl pkg-config unzip python3-pip \
+	libssl-dev libopus-dev qt515base qt515multimedia qt515svg \
+	libgl1-mesa-dev nasm libudev-dev libva-dev fuse libevdev-dev libudev-dev \
+        libhidapi-dev libpipewire-0.3-dev libfftw3-dev libspeexdsp-dev 
+CMD [] 

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -7,7 +7,7 @@ appdir=${1:-`pwd`/appimage/appdir}
 
 mkdir appimage
 
-pip3 install --user protobuf==3.19.5 # need support for python 3.6 for running on bionic
+pip3 install --user protobuf==3.19.5
 scripts/fetch-protoc.sh appimage
 export PATH="`pwd`/appimage/protoc/bin:$PATH"
 scripts/build-ffmpeg.sh appimage
@@ -20,7 +20,6 @@ cmake \
 	-DCMAKE_BUILD_TYPE=Release \
 	"-DCMAKE_PREFIX_PATH=`pwd`/../appimage/ffmpeg-prefix;`pwd`/../appimage/sdl2-prefix;/opt/qt512" \
 	-DCHIAKI_ENABLE_TESTS=ON \
-	-DCHIAKI_ENABLE_CLI=OFF \
 	-DCHIAKI_ENABLE_GUI=ON \
 	-DCHIAKI_GUI_ENABLE_SDL_GAMECONTROLLER=ON \
 	-DCMAKE_INSTALL_PREFIX=/usr \
@@ -41,7 +40,7 @@ chmod +x linuxdeploy-x86_64.AppImage
 curl -L -O https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
 chmod +x linuxdeploy-plugin-qt-x86_64.AppImage
 set +e
-source /opt/qt512/bin/qt512-env.sh
+source /opt/qt515/bin/qt515-env.sh
 set -e
 
 export LD_LIBRARY_PATH="`pwd`/sdl2-prefix/lib:$LD_LIBRARY_PATH"

--- a/scripts/build-ffmpeg.sh
+++ b/scripts/build-ffmpeg.sh
@@ -5,10 +5,10 @@ cd "./$1"
 shift
 ROOT="`pwd`"
 
-TAG=n4.3.1
+TAG=n6.1
 
 git clone https://git.ffmpeg.org/ffmpeg.git --depth 1 -b $TAG && cd ffmpeg || exit 1
 
-./configure --disable-all --enable-avcodec --enable-decoder=h264 --enable-decoder=hevc --enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi --prefix="$ROOT/ffmpeg-prefix" "$@" || exit 1
+./configure --disable-all --enable-avcodec --enable-decoder=h264 --enable-decoder=hevc --enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi --enable-hwaccel=h264_vulkan --enable-hwaccel=hevc_vulkan --prefix="$ROOT/ffmpeg-prefix" "$@" || exit 1
 make -j4 || exit 1
 make install || exit 1

--- a/scripts/flatpak/chiaki4deck-devel.yaml
+++ b/scripts/flatpak/chiaki4deck-devel.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.streetpea.Chiaki4deck-devel
 runtime: org.kde.Platform
-runtime-version: '5.15-22.08'
+runtime-version: '5.15-23.08'
 sdk: org.kde.Sdk
 command: chiaki
 rename-icon: chiaki4deck
@@ -42,8 +42,8 @@ modules:
       - --enable-encoder=png
     sources:
       - type: archive
-        url: https://ffmpeg.org/releases/ffmpeg-6.0.tar.xz
-        sha256: 57be87c22d9b49c112b6d24bc67d42508660e6b718b3db89c44e47e289137082 
+        url: https://ffmpeg.org/releases/ffmpeg-6.1.tar.xz
+        sha256: 488c76e57dd9b3bee901f71d5c95eaf1db4a5a31fe46a28654e837144207c270
 
   - name: python3-google
     buildsystem: simple

--- a/scripts/flatpak/chiaki4deck.yaml
+++ b/scripts/flatpak/chiaki4deck.yaml
@@ -1,7 +1,7 @@
 app-id: io.github.streetpea.Chiaki4deck
 branch: chiaki4deck
 runtime: org.kde.Platform
-runtime-version: '5.15-22.08'
+runtime-version: '5.15-23.08'
 sdk: org.kde.Sdk
 command: chiaki
 rename-icon: chiaki4deck
@@ -19,6 +19,10 @@ finish-args:
   - --env=DBUS_FATAL_WARNINGS=0
   - --talk-name=org.freedesktop.ScreenSaver
   - --filesystem=xdg-run/pipewire-0
+  - --filesystem=xdg-run/gamescope-0
+  - --filesystem=host
+  - --env=VK_LAYER_PATH=/app/vulkan-layers/
+  - --env=VK_INSTANCE_LAYERS=VK_LAYER_FROG_gamescope_wsi_x86_64:VK_LAYER_FROG_gamescope_wsi_x86
   
 modules:
   - name: protobuf-compilers
@@ -42,10 +46,12 @@ modules:
       - --enable-decoder=hevc
       - --enable-hwaccel=h264_vaapi
       - --enable-hwaccel=hevc_vaapi
+      - --enable-hwaccel=h264_vulkan
+      - --enable-hwaccel=hevc_vulkan
     sources:
       - type: archive
-        url: https://ffmpeg.org/releases/ffmpeg-6.0.tar.xz
-        sha256: 57be87c22d9b49c112b6d24bc67d42508660e6b718b3db89c44e47e289137082
+        url: https://ffmpeg.org/releases/ffmpeg-6.1.tar.xz
+        sha256: 488c76e57dd9b3bee901f71d5c95eaf1db4a5a31fe46a28654e837144207c270
 
   - name: python3-google
     buildsystem: simple
@@ -118,6 +124,71 @@ modules:
         url: https://github.com/libusb/hidapi.git
         tag: hidapi-0.14.0
 
+  - name: libplacebo
+    buildsystem: meson
+    config-opts:
+      - -Dvulkan=enabled
+      - -Dshaderc=enabled
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: git
+        url: https://github.com/haasn/libplacebo
+        tag: v6.338.1
+    modules:
+      - name: shaderc
+        buildsystem: cmake-ninja
+        builddir: true
+        config-opts:
+          - -DSHADERC_SKIP_COPYRIGHT_CHECK=ON
+          - -DSHADERC_SKIP_EXAMPLES=ON
+          - -DSHADERC_SKIP_TESTS=ON
+          - -DSPIRV_SKIP_EXECUTABLES=ON
+          - -DENABLE_GLSLANG_BINARIES=OFF
+        cleanup:
+         - /bin
+         - /include
+         - /lib/cmake
+         - /lib/pkgconfig
+        sources:
+          - type: git
+            url: https://github.com/google/shaderc.git
+            tag: v2023.7
+            commit: 3882b16417077aa8eaa7b5775920e7ba4b8a224d
+            x-checker-data:
+              type: git
+              tag-pattern: ^v(\d{4}\.\d{1,2})$
+          - type: git
+            url: https://github.com/KhronosGroup/SPIRV-Tools.git
+            tag: v2023.2
+            commit: 44d72a9b36702f093dd20815561a56778b2d181e
+            dest: third_party/spirv-tools
+            x-checker-data:
+              type: git
+              tag-pattern: ^v(\d{4}\.\d{1})$
+          - type: git
+            url: https://github.com/KhronosGroup/SPIRV-Headers.git
+            tag: sdk-1.3.250.1
+            commit: 268a061764ee69f09a477a695bf6a11ffe311b8d
+            dest: third_party/spirv-headers
+          - type: git
+            url: https://github.com/KhronosGroup/glslang.git
+            tag: 13.1.1
+            commit: 36d08c0d940cf307a23928299ef52c7970d8cee6
+            dest: third_party/glslang
+            x-checker-data:
+              type: git
+              tag-pattern: ^(\d{1,2}\.\d{1,2}\.\d{1,4})$
+
+  - name: vulkanso
+    buildsystem: simple
+    build-commands:
+      - |
+        cp /usr/lib/x86_64-linux-gnu/libvulkan.so.1.3.261 /app/lib/libvulkan.so.1.3.261
+        ln -s libvulkan.so.1.3.261 /app/lib/libvulkan.so.1
+        ln -s libvulkan.so.1 /app/lib/libvulkan.so
+
   - name: chiaki4deck
     buildsystem: cmake
     builddir: true
@@ -127,3 +198,5 @@ modules:
         branch: chiaki4deck
     post-install:
       - "install -Dm755 ../scripts/psn-account-id.py /app/bin/psn-account-id"
+      - "install -Dm755 ../scripts/vulkan-gamescope-layers/VkLayer_FROG_gamescope_wsi.x86.json /app/vulkan-layers/VkLayer_FROG_gamescope_wsi.x86_64.json"
+      - "install -Dm755 ../scripts/vulkan-gamescope-layers/VkLayer_FROG_gamescope_wsi.x86_64.json /app/vulkan-layers/VkLayer_FROG_gamescope_wsi.x86_64.json"

--- a/scripts/run-podman-build-appimage.sh
+++ b/scripts/run-podman-build-appimage.sh
@@ -3,13 +3,13 @@
 set -xe
 cd "`dirname $(readlink -f ${0})`"
 
-podman build -t chiaki-bionic . -f Dockerfile.bionic
+podman build -t chiaki-focal . -f Dockerfile.focal
 cd ..
 podman run --rm \
 	-v "`pwd`:/build/chiaki" \
 	-w "/build/chiaki" \
 	--device /dev/fuse \
 	--cap-add SYS_ADMIN \
-	-t chiaki-bionic \
+	-t chiaki-focal \
 	/bin/bash -c "scripts/build-appimage.sh /build/appdir"
 

--- a/scripts/vulkan-gamescope-layers/VkLayer_FROG_gamescope_wsi.x86.json
+++ b/scripts/vulkan-gamescope-layers/VkLayer_FROG_gamescope_wsi.x86.json
@@ -1,0 +1,20 @@
+{
+    "file_format_version" : "1.0.0",
+    "layer" : {
+      "name": "VK_LAYER_FROG_gamescope_wsi_x86",
+      "type": "GLOBAL",
+      "api_version": "1.3.221",
+      "library_path": "/var/run/host/usr/lib32/libVkLayer_FROG_gamescope_wsi_x86.so",
+      "implementation_version": "1",
+      "description": "Gamescope WSI (XWayland Bypass) Layer (x86)",
+      "functions": {
+         "vkNegotiateLoaderLayerInterfaceVersion": "vkNegotiateLoaderLayerInterfaceVersion"
+      },
+      "enable_environment": {
+        "ENABLE_GAMESCOPE_WSI": "1"
+      },
+      "disable_environment": {
+        "DISABLE_GAMESCOPE_WSI": "1"
+      }
+    }
+}

--- a/scripts/vulkan-gamescope-layers/VkLayer_FROG_gamescope_wsi.x86_64.json
+++ b/scripts/vulkan-gamescope-layers/VkLayer_FROG_gamescope_wsi.x86_64.json
@@ -1,0 +1,20 @@
+{
+    "file_format_version" : "1.0.0",
+    "layer" : {
+      "name": "VK_LAYER_FROG_gamescope_wsi_x86_64",
+      "type": "GLOBAL",
+      "api_version": "1.3.221",
+      "library_path": "/var/run/host/usr/lib/libVkLayer_FROG_gamescope_wsi_x86_64.so",
+      "implementation_version": "1",
+      "description": "Gamescope WSI (XWayland Bypass) Layer (x86_64)",
+      "functions": {
+         "vkNegotiateLoaderLayerInterfaceVersion": "vkNegotiateLoaderLayerInterfaceVersion"
+      },
+      "enable_environment": {
+        "ENABLE_GAMESCOPE_WSI": "1"
+      },
+      "disable_environment": {
+        "DISABLE_GAMESCOPE_WSI": "1"
+      }
+    }
+}


### PR DESCRIPTION
Add game scope layers to build script, switch back to clock join for threads w/ update to focal for appimage, and use swap chain colorspace hint to select color space based on av frame. After initial frame is picked, placebo will update colorspace based on the incoming frame. This means if you select H265 HDR mode it will select an HDR output colorspace and if you select an SDR mode it will select and SDR output colorspace.